### PR TITLE
Some refactorings

### DIFF
--- a/pkg/cache/defs.go
+++ b/pkg/cache/defs.go
@@ -8,10 +8,3 @@ type CacheElement[T any] struct {
 	CreatedAt time.Time
 	TTL       time.Duration
 }
-
-type Cache[T any] interface {
-	Get(key string) (CacheElement[T], bool)
-	Put(key string, value T)
-	GetAllKeyValues() map[string]T
-	AutoCleanUp(checkInterval time.Duration, done <-chan bool)
-}

--- a/pkg/cache/options.go
+++ b/pkg/cache/options.go
@@ -1,0 +1,30 @@
+package cache
+
+import (
+	"time"
+)
+
+// Options like sweeping funcitonality, cache size, etc
+type Options struct {
+	sweepInterval time.Duration
+}
+
+func (os *Options) Apply(o ...Option) error {
+	for _, o := range o {
+		if err := o(os); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+type Option func(options *Options) error
+
+// WithSweeping make sure that sweeping with happen at specified interval
+func WithSweeping(interval time.Duration) Option {
+	return func(options *Options) error {
+		options.sweepInterval = interval
+		return nil
+	}
+}


### PR DESCRIPTION
- using signal notify context: better than explicitly handling os signals using a channel, easy and clean code for client.
- using snyc.Map: easy readability and less complex for concurrent map handling
- adding Options: make it clean for the client to have option for different settings in the cache(eg: Cache size, Sweeping functionality)